### PR TITLE
Relax requirements of x- and y- coordinate being of same type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 0.5.6 (2024-09-16)
+
+### Bugfix
+
+* Relax requirements of x- and y- coordinate being of same type.
+
 ## Version 0.5.5 (2024-09-13)
 
 ### Bugfix

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsGUI"
 uuid = "737a7361-d3b7-40e9-b1ac-59bee4c5ea2d"
 authors = ["Jon Vegard Venås <JonVegard.Venas@sintef.no>", "Magnus Askeland <Magnus.Askeland@sintef.no>", "Shweta Tiwari <Shweta.Tiwari@sintef.no>"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ using EnergyModelsGUI
 GUI(case)
 ```
 
-Please refer to the [documentation](https://clean_export.pages.sintef.no/energymodelsgui.jl/) for more details.
+Please refer to the [documentation](https://energymodelsx.github.io/EnergyModelsGUI.jl/stable/) for more details.
 
 See examples of usage of the package and a simple guide for running them in the folder [`examples`](examples).
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,7 +47,6 @@ makedocs(;
             "Internals" => Any["Reference" => "library/internals/reference.md",],
         ],
     ],
-    checkdocs=:all,
 )
 
 deploydocs(; repo="github.com/EnergyModelsX/EnergyModelsGUI.jl.git")

--- a/docs/src/how-to/customize-descriptive_names.md
+++ b/docs/src/how-to/customize-descriptive_names.md
@@ -36,3 +36,22 @@ gui = GUI(
     descriptive_names_dict=descriptive_names_dict,
 )
 ```
+The variables for `total` quantities (and their descriptions) can be customized in the same manner (see structure in the `src/descriptive_names.yml` file).
+
+It is also possible to ignore certain `JuMP` variables. I.e., ignoring `cap_use` and `flow_in` (in addition to the variable `con_em_tot` which is ignored by default) can be done as follows
+```julia
+gui = GUI(
+    case;
+    model=m,
+    path_to_descriptive_names=path_to_descriptive_names,
+    descriptive_names_dict=Dict(:ignore => ["con_em_tot", "cap_use", "flow_in"]),
+)
+```
+You can similarly customize variables that indicates an investment has occured `investment_indicators` the default variables are
+```
+  - cap_add
+  - trans_cap_add
+  - stor_level_add
+  - stor_charge_add
+  - stor_discharge_add
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,7 +11,7 @@ One of the primary design goals was to develop a model that can eaily be extende
 
 For running and visualizing a basic energy system model, only the base technology package
 [`EnergyModelsBase.jl`](https://github.com/EnergyModelsX/EnergyModelsBase.jl.git),
-[`EnergyModelsGUI.jl`](https://clean_export.pages.sintef.no/energymodelsgui.jl/)
+[`EnergyModelsGUI.jl`](https://github.com/EnergyModelsX/EnergyModelsGUI.jl.git)
 and the time structure package
 [`TimeStruct.jl`](https://github.com/sintefore/TimeStruct.jl/releases)
 are needed.

--- a/src/setup_topology.jl
+++ b/src/setup_topology.jl
@@ -136,8 +136,7 @@ Processes children or components within an energy system design and populates th
 - **`id_to_color_map::Dict`** is a dictionary of resources and their assigned colors.
 - **`id_to_icon_map::Dict`** is a dictionary of nodes and their assigned icons.
 - **`parent::Symbol`** is a symbol representing the parent of the children.
-- **`parent_xy::Tuple{T,T}`** is a tuple holding the coordinates of the parent,
-  where `T` is a subtype of Real.
+- **`parent_xy::Tuple{<:Real,<:Real}`** is a tuple holding the coordinates of the parent.
 """
 function process_children!(
     children::Vector{EnergySystemDesign},
@@ -147,8 +146,8 @@ function process_children!(
     id_to_color_map::Dict,
     id_to_icon_map::Dict,
     parent::Symbol,
-    parent_xy::Tuple{T,T},
-) where {T<:Real}
+    parent_xy::Tuple{<:Real,<:Real},
+)
     # Create an iterator for the current systems
     systems_iterator::Union{
         Iterators.Enumerate{Vector{EMB.Node}},Iterators.Enumerate{Vector{Area}},Nothing


### PR DESCRIPTION
A bug arose when providing coordinates of different types (i.e. Float64 and Int64). This PR relax requirements of x- and y- coordinate being of same type. Also fix documentation and incorrect links.