### PR TITLE
Fix redundant color input and path to descriptive_names.yml

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## Version 0.5.11 (2025-02-01)
+
+### Bugfix
+
+* Fix bug that occured when providing a color for a `Resource.id` not present in `products` for the `id_to_color_map`-argument of the `GUI`-function.
+* Fix the path to the `descriptive_names.yml` file of an EMX package.
+
 ## Version 0.5.10 (2024-12-13)
 
 ### Bugfix

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsGUI"
 uuid = "737a7361-d3b7-40e9-b1ac-59bee4c5ea2d"
 authors = ["Jon Vegard Venås <JonVegard.Venas@sintef.no>", "Magnus Askeland <Magnus.Askeland@sintef.no>", "Shweta Tiwari <Shweta.Tiwari@sintef.no>"]
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"

--- a/src/utils_GUI/GUI_utils.jl
+++ b/src/utils_GUI/GUI_utils.jl
@@ -547,7 +547,7 @@ function update_descriptive_names!(gui::GUI)
         package_path::Union{String,Nothing} = Base.find_package(package)
         if !isnothing(package_path)
             path_to_descriptive_names_ext = joinpath(
-                package_path, "ext", "EMGUIExt", "descriptive_names.yml",
+                package_path, "..", "..", "ext", "EMGUIExt", "descriptive_names.yml",
             )
             if isfile(path_to_descriptive_names_ext)
                 descriptive_names_dict_ext_file = YAML.load_file(


### PR DESCRIPTION
This PR resolves the following bugs:
- Fix the bug that occurred when providing color for a `Resource.id` that is not present in `products` for the `id_to_color_map`-argument of the `GUI`-function.
- Fix the path to the `descriptive_names.yml` file of an EMX package.