### PR TITLE
Fix/breaking GeoMakie version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## Version 0.5.14 (2025-06-25)
+
+### Bugfix
+
+* Fix bug from breaking changes in GeoMakie v0.7.13 on Windows.
+* Don't show warning for unfeasible JuMP solution when the provided model is empty.
+
 ## Version 0.5.13 (2025-06-02)
 
 ### Bugfix

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsGUI"
 uuid = "737a7361-d3b7-40e9-b1ac-59bee4c5ea2d"
 authors = ["Jon Vegard Venås <JonVegard.Venas@sintef.no>", "Magnus Askeland <Magnus.Askeland@sintef.no>", "Shweta Tiwari <Shweta.Tiwari@sintef.no>"]
-version = "0.5.13"
+version = "0.5.14"
 
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
@@ -40,7 +40,7 @@ EnergyModelsInvestments = "0.8"
 FileIO = "1.16"
 GLMakie = "0.10.5"
 GeoJSON = "0.8"
-GeoMakie = "0.7.3"
+GeoMakie = "=0.7.12"
 HTTP = "1.10"
 ImageMagick = "1.3"
 JuMP = "1.22"

--- a/src/utils_GUI/GUI_utils.jl
+++ b/src/utils_GUI/GUI_utils.jl
@@ -388,7 +388,9 @@ function initialize_available_data!(gui)
         end
         get_ax(gui, :summary).scene.plots[1][1][] = investment_overview
     else
-        @warn "Total quantities were not computed as model does not contain a feasible solution"
+        if !isempty(model)
+            @warn "Total quantities were not computed as model does not contain a feasible solution"
+        end
     end
 
     # Add case input data


### PR DESCRIPTION
GeoMakie@0.7.13 introduced a breaking change on windows resulting in stack overflow. This PR simply enforces version GeoMakie@0.7.12. Also avoided warning for unfeasible JuMP solution when the provided model is empty.