### PR TITLE
Enhance/description of dict fields

### DIFF
--- a/src/utils_GUI/GUI_utils.jl
+++ b/src/utils_GUI/GUI_utils.jl
@@ -403,7 +403,8 @@ function initialize_available_data!(gui)
                 structure = String(nameof(typeof(element)))
                 name = "$field_name"
                 key_str = "structures.$structure.$name"
-                add_description!(field, name, key_str, "", element, available_data, gui)
+                selection = Vector{Any}([element])
+                add_description!(field, name, key_str, "", selection, available_data, gui)
             end
             append!(get_available_data(gui)[element], available_data)
         end
@@ -539,10 +540,10 @@ function update_descriptive_names!(gui::GUI)
 
     # Search through EMX packages if icons are available there
     for package ∈ emx_packages
-        package_path::Union{String,Nothing} = Base.find_package(package)
+        package_path::Union{String,Nothing} = dirname(dirname(Base.find_package(package)))
         if !isnothing(package_path)
             path_to_descriptive_names_ext = joinpath(
-                package_path, "..", "..", "ext", "EMGUIExt", "descriptive_names.yml",
+                package_path, "ext", "EMGUIExt", "descriptive_names.yml",
             )
             if isfile(path_to_descriptive_names_ext)
                 descriptive_names_dict_ext_file = YAML.load_file(

--- a/src/utils_GUI/results_axis_utils.jl
+++ b/src/utils_GUI/results_axis_utils.jl
@@ -27,7 +27,7 @@ end
         name::String,
         key_str::String,
         pre_desc::String,
-        element,
+        selection::Vector,
         available_data::Vector{Dict},
         gui::GUI,
     )
@@ -39,14 +39,14 @@ function add_description!(
     name::String,
     key_str::String,
     pre_desc::String,
-    element,
+    selection::Vector,
     available_data::Vector{Dict},
     gui::GUI,
 )
     container = Dict(
         :name => name,
         :is_jump_data => false,
-        :selection => [element],
+        :selection => selection,
         :field_data => field,
         :description => create_description(gui, key_str; pre_desc),
     )
@@ -59,7 +59,7 @@ end
         name::String,
         key_str::String,
         pre_desc::String,
-        element,
+        selection::Vector,
         available_data::Vector{Dict},
         gui::GUI,
     )
@@ -72,15 +72,23 @@ function add_description!(
     name::String,
     key_str::String,
     pre_desc::String,
-    element,
+    selection::Vector,
     available_data::Vector{Dict},
     gui::GUI,
 )
     for (dictname, dictvalue) ∈ field
-        name_field = "$name.$dictname"
-        key_str_field = "$key_str.$dictname"
+        name_field = "$name"
+        key_str_field = "$key_str"
+        ext_selection = deepcopy(selection)
+        if isa(dictname, Resource)
+            push!(ext_selection, dictname)
+        else
+            name_field *= ".$dictname"
+            key_str_field *= ".$dictname"
+        end
         add_description!(
-            dictvalue, name_field, key_str_field, pre_desc, element, available_data, gui,
+            dictvalue, name_field, key_str_field, pre_desc, ext_selection, available_data,
+            gui,
         )
     end
 end
@@ -91,7 +99,7 @@ end
         name::String,
         key_str::String,
         pre_desc::String,
-        element,
+        selection::Vector,
         available_data::Vector{Dict},
         gui::GUI,
     )
@@ -104,7 +112,7 @@ function add_description!(
     name::String,
     key_str::String,
     pre_desc::String,
-    element,
+    selection::Vector,
     available_data::Vector{Dict},
     gui::GUI,
 )
@@ -113,7 +121,7 @@ function add_description!(
         name_field = "$name.$data_type"
         key_str_field = "$key_str.$data_type"
         add_description!(
-            data, name_field, key_str_field, pre_desc, element, available_data, gui,
+            data, name_field, key_str_field, pre_desc, selection, available_data, gui,
         )
     end
 end
@@ -137,7 +145,7 @@ function add_description!(
     name::String,
     key_str::String,
     pre_desc::String,
-    element,
+    selection::Vector,
     available_data::Vector{Dict},
     gui::GUI,
 )
@@ -153,7 +161,7 @@ function add_description!(
         pre_desc_sub = "$pre_desc$name_field_type: "
         key_str = "structures.$name_field_type.$sub_field_name"
         add_description!(
-            sub_field, name_field, key_str, pre_desc_sub, element, available_data, gui,
+            sub_field, name_field, key_str, pre_desc_sub, selection, available_data, gui,
         )
     end
 end
@@ -305,7 +313,7 @@ function create_label(selection::Dict{Symbol,Any})
         label *= selection[:name]
     end
     otherRes::Bool = false
-    if length(selection) > 1
+    if length(selection[:selection]) > 1
         for select ∈ selection[:selection]
             if isa(select, Resource)
                 if !otherRes

--- a/src/utils_GUI/results_axis_utils.jl
+++ b/src/utils_GUI/results_axis_utils.jl
@@ -313,22 +313,20 @@ function create_label(selection::Dict{Symbol,Any})
         label *= selection[:name]
     end
     otherRes::Bool = false
-    if length(selection[:selection]) > 1
-        for select ∈ selection[:selection]
-            if isa(select, Resource)
-                if !otherRes
-                    label *= " ("
-                    otherRes = true
-                end
-                label *= "$(select)"
-                if select != selection[:selection][end]
-                    label *= ", "
-                end
+    for select ∈ selection[:selection]
+        if isa(select, Resource)
+            if !otherRes
+                label *= " ("
+                otherRes = true
+            end
+            label *= "$(select)"
+            if select != selection[:selection][end]
+                label *= ", "
             end
         end
-        if otherRes
-            label *= ")"
-        end
+    end
+    if otherRes
+        label *= ")"
     end
     return label
 end


### PR DESCRIPTION
Enhance the descriptive names for nodes having dictionaries with keys of type `Resource` as in the [MultipleBuildingTypes](https://github.com/EnergyModelsX/EnergyModelsLanguageInterfaces.jl/blob/1ba89410753c7395e62370a01f12ee0ba6c37c50/src/datastructures.jl#L360C11-L360C29)-node in the [EnergyModelsLanguageInterfaces.jl](https://github.com/EnergyModelsX/EnergyModelsLanguageInterfaces.jl). Testing this functionality should be added once the package is registered.

Also cleaned up some code.