### PR TITLE
Fix/missing header type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 0.6.2 (2025-12-18)
+
+### Bugfix
+
+* Fix missing header type for type `Int` used in the exported function `save_results` (e.g., for the variable `:discharge_segment` in `EnergyModelsRenewableProducers`).
+
 ## Version 0.6.1 (2025-12-17)
 
 ### Enhancements

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EnergyModelsGUI"
 uuid = "737a7361-d3b7-40e9-b1ac-59bee4c5ea2d"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Jon Vegard Venås <JonVegard.Venas@sintef.no>", "Dimitri Pinel <Dimitri.Pinel@sintef.no>", "Magnus Askeland <Magnus.Askeland@sintef.no>", "Shweta Tiwari <Shweta.Tiwari@sintef.no>"]
 
 [deps]

--- a/src/utils_gen/utils.jl
+++ b/src/utils_gen/utils.jl
@@ -229,6 +229,7 @@ _type_to_header(::Type{<:TS.TimePeriod}) = :t
 _type_to_header(::Type{<:TS.TimeStructure}) = :t
 _type_to_header(::Type{<:Resource}) = :res
 _type_to_header(::Type{<:AbstractElement}) = :element
+_type_to_header(::Type{<:Int}) = :segment
 
 """
     save_results(model::Model; directory=joinpath(pwd(),"csv_files"))


### PR DESCRIPTION
Fix missing header type for type `Int` used in the exported function `save_results` (e.g., for the variable `:discharge_segment` in `EnergyModelsRenewableProducers`).